### PR TITLE
Make ConvRNN compatible with PyTorch 0.4

### DIFF
--- a/conv_rnn/model.py
+++ b/conv_rnn/model.py
@@ -72,8 +72,8 @@ class ConvRNNModel(nn.Module):
         x = nn_func.relu(x) # shape: (batch, channels, seq len)
         x = nn_func.max_pool1d(x, x.size(2)) # shape: (batch, channels)
         out = [t.squeeze(1) for t in rnn_out.chunk(2, 1)]
-        out.append(x)
-        x = torch.cat(out, 1).squeeze(2)
+        out.append(x.squeeze(-1))
+        x = torch.cat(out, 1)
         x = nn_func.relu(self.fc1(x))
         return self.fc2(x)
 

--- a/conv_rnn/train.py
+++ b/conv_rnn/train.py
@@ -94,7 +94,7 @@ def train(**kwargs):
         for m_in, m_out in loader:
             scores = conv_rnn(m_in)
             loss = criterion(scores, m_out).cpu().data[0]
-            n_correct = (torch.max(scores, 1)[1].view(m_in.size(0)).data == m_out.data).sum()
+            n_correct = (torch.max(scores, 1)[1].view(m_in.size(0)).data == m_out.data).float().sum().item()
             accuracy = n_correct / m_in.size(0)
             scheduler.step(accuracy)
             if dev and accuracy >= evaluate.best_dev:
@@ -122,7 +122,7 @@ def train(**kwargs):
             loss = criterion(scores, train_out)
             loss.backward()
             optimizer.step()
-            accuracy = (torch.max(scores, 1)[1].view(-1).data == train_out.data).sum() / mbatch_size
+            accuracy = (torch.max(scores, 1)[1].view(-1).data == train_out.data).float().sum() / mbatch_size
             if verbose and i % (mbatch_size * 10) == 0:
                 print("accuracy: {}, {} / {}".format(accuracy, j * mbatch_size, len(train_set)))
             i += mbatch_size


### PR DESCRIPTION
- Some ops now result in outputs with fewer dimensions
- Convert ByteTensors to floats using `.float()` 